### PR TITLE
Set active for paths like "/foo/#bar" in NavLink.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -88,7 +88,7 @@ export function NavHashLink(props) {
         if (typeof props.to === 'string') {
           return window.location.pathname + window.location.hash === props.to;
         } else if (typeof props.to === 'object' && typeof props.to.hash === 'string'){
-          return window.location.pathname === props.to.pathname && window.location.hash === props.to.hash;
+          return window.location.pathname === props.to.pathname && window.location.hash.replace('#', '') === props.to.hash;
         }
         
       }

--- a/src/index.js
+++ b/src/index.js
@@ -85,7 +85,12 @@ export function NavHashLink(props) {
   if (!props.isActive) {
     props = Object.assign({
       isActive: () => {
-        return window.location.pathname + window.location.hash === props.to;
+        if (typeof props.to === 'string') {
+          return window.location.pathname + window.location.hash === props.to;
+        } else if (typeof props.to === 'object' && typeof props.to.hash === 'string'){
+          return window.location.pathname === props.to.pathname && window.location.hash === props.to.hash;
+        }
+        
       }
     }, props)
   }

--- a/src/index.js
+++ b/src/index.js
@@ -82,6 +82,13 @@ export function HashLink(props) {
 }
 
 export function NavHashLink(props) {
+  if (!props.isActive) {
+    props = Object.assign({
+      isActive: () => {
+        return window.location.pathname + window.location.hash === props.to;
+      }
+    }, props)
+  }
   return genericHashLink(props, NavLink);
 }
 


### PR DESCRIPTION
Unfortunately React sets NavLink with hash paths only active when they have following scheme:
`/foo#bar
`

But I am using this scheme:
`/foo/#bar`

So this sets also NavLinks active with my scheme.
